### PR TITLE
The "Add..." context menu in Messages editor: two bugs #27

### DIFF
--- a/org.eclipse.babel.core/src/org/eclipse/babel/core/message/internal/MessagesBundleGroup.java
+++ b/org.eclipse.babel.core/src/org/eclipse/babel/core/message/internal/MessagesBundleGroup.java
@@ -118,7 +118,9 @@ public class MessagesBundleGroup extends AbstractMessageModel implements
      */
     @Override
     public IMessagesBundle getMessagesBundle(Locale locale) {
-        return localeBundles.get(locale);
+    	// The ROOT locale is currently stored as a null key in the HashMap, need to swap it!
+    	Locale localeToUse = locale == Locale.ROOT ? null : locale;
+        return localeBundles.get(localeToUse);
     }
 
     /**

--- a/org.eclipse.babel.editor/messages.properties
+++ b/org.eclipse.babel.editor/messages.properties
@@ -11,6 +11,7 @@ dialog.duplicate.body.single   = Duplicate "{0}" to:
 dialog.duplicate.head.multiple = Duplicate key group
 dialog.duplicate.head.single   = Duplicate key
 dialog.error.exists            = This key already exists.
+dialog.error.invalidkey        = Invalid key.
 dialog.identical.body          = Below are keys having identical value as key "{0}" within the locale "{1}":
 dialog.identical.head          = Identical value(s) found.
 dialog.rename.body.multiple    = Rename key group "{0}" to (all nested keys will be renamed):

--- a/org.eclipse.babel.editor/src/org/eclipse/babel/editor/i18n/SideNavTextBoxComposite.java
+++ b/org.eclipse.babel.editor/src/org/eclipse/babel/editor/i18n/SideNavTextBoxComposite.java
@@ -10,6 +10,11 @@
  ******************************************************************************/
 package org.eclipse.babel.editor.i18n;
 
+import java.util.Locale;
+
+import org.eclipse.babel.core.message.IMessagesBundle;
+import org.eclipse.babel.core.message.internal.MessagesBundle;
+import org.eclipse.babel.core.message.internal.MessagesBundleGroup;
 import org.eclipse.babel.core.message.tree.IKeyTreeNode;
 import org.eclipse.babel.core.message.tree.visitor.NodePathRegexVisitor;
 import org.eclipse.babel.editor.internal.AbstractMessagesEditor;
@@ -120,8 +125,12 @@ public class SideNavTextBoxComposite extends Composite {
     }
 
     private void addKey(String key) {
-        editor.getBundleGroup().addMessages(key);
-        editor.setSelectedKey(key);
+        MessagesBundleGroup messagesBundleGroup = editor.getBundleGroup();
+        IMessagesBundle messagesBundle = messagesBundleGroup.getMessagesBundle(Locale.ROOT);
+        if (messagesBundle instanceof MessagesBundle theBundle) {
+            theBundle.addMessage(key);
+            editor.setSelectedKey(key);
+        }
     }
 
     private boolean isNewKey(String key) {

--- a/org.eclipse.babel.editor/src/org/eclipse/babel/editor/tree/actions/AddKeyAction.java
+++ b/org.eclipse.babel.editor/src/org/eclipse/babel/editor/tree/actions/AddKeyAction.java
@@ -10,6 +10,10 @@
  ******************************************************************************/
 package org.eclipse.babel.editor.tree.actions;
 
+import java.util.Locale;
+
+import org.eclipse.babel.core.message.IMessagesBundle;
+import org.eclipse.babel.core.message.internal.MessagesBundle;
 import org.eclipse.babel.core.message.internal.MessagesBundleGroup;
 import org.eclipse.babel.core.message.tree.internal.KeyTreeNode;
 import org.eclipse.babel.editor.internal.AbstractMessagesEditor;
@@ -43,15 +47,17 @@ public class AddKeyAction extends AbstractTreeAction {
     @Override
     public void run() {
         KeyTreeNode node = getNodeSelection();
-        String key = node.getMessageKey();
+        String selectedKey = node != null ? node.getMessageKey() : "";
         String msgHead = MessagesEditorPlugin.getString("dialog.add.head");
         String msgBody = MessagesEditorPlugin.getString("dialog.add.body");
-        InputDialog dialog = new InputDialog(getShell(), msgHead, msgBody, key,
+        InputDialog dialog = new InputDialog(getShell(), msgHead, msgBody, selectedKey,
                 new IInputValidator() {
                     public String isValid(String newText) {
                         if (getBundleGroup().isMessageKey(newText)) {
                             return MessagesEditorPlugin
                                     .getString("dialog.error.exists");
+                        } else if (newText.isBlank()) {
+                        	return MessagesEditorPlugin.getString("dialog.error.invalidkey");
                         }
                         return null;
                     }
@@ -60,7 +66,10 @@ public class AddKeyAction extends AbstractTreeAction {
         if (dialog.getReturnCode() == Window.OK) {
             String inputKey = dialog.getValue();
             MessagesBundleGroup messagesBundleGroup = getBundleGroup();
-            messagesBundleGroup.addMessages(inputKey);
+            IMessagesBundle messagesBundle = messagesBundleGroup.getMessagesBundle(Locale.ROOT);
+            if ( messagesBundle instanceof MessagesBundle theBundle ) {
+            	theBundle.addMessage(inputKey);
+            }
         }
     }
 


### PR DESCRIPTION
Fixed NPE and switched behaviour for the "Add" action so that it only adds a new key to the ROOT locale