### PR TITLE
DuplicateValueCheck in MessagesBundleGroupValidator does not work #23

### DIFF
--- a/org.eclipse.babel.editor/src/org/eclipse/babel/editor/resource/validator/MessagesBundleGroupValidator.java
+++ b/org.eclipse.babel.editor/src/org/eclipse/babel/editor/resource/validator/MessagesBundleGroupValidator.java
@@ -31,8 +31,8 @@ public class MessagesBundleGroupValidator {
         // already open.
         // else, create MessagesBundle from PropertiesIFileResource
 
-        DuplicateValueCheck duplicateCheck = MsgEditorPreferences.getInstance()
-                .getReportDuplicateValues() ? new DuplicateValueCheck() : null;
+    	boolean performDuplicateValueCheck = MsgEditorPreferences.getInstance().getReportDuplicateValues();
+
         String[] keys = messagesBundleGroup.getMessageKeys();
         for (int i = 0; i < keys.length; i++) {
             String key = keys[i];
@@ -44,19 +44,19 @@ public class MessagesBundleGroupValidator {
                             MissingValueCheck.MISSING_KEY));
                 }
             }
-            if (duplicateCheck != null) {
+            if (performDuplicateValueCheck) {
                 if (!MsgEditorPreferences.getInstance()
                         .getReportDuplicateValuesOnlyInRootLocales()
-                        || (locale == null || locale.toString().length() == 0)) {
+                        || (locale == null || locale.toString().length() == 0) ) {
                     // either the locale is the root locale either
                     // we report duplicated on all the locales anyways.
-                    if (duplicateCheck.checkKey(messagesBundleGroup,
+                    DuplicateValueCheck duplicateCheck = new DuplicateValueCheck();
+                	if (duplicateCheck.checkKey(messagesBundleGroup,
                             messagesBundleGroup.getMessage(key, locale))) {
                         markerStrategy.markFailed(new ValidationFailureEvent(
                                 messagesBundleGroup, locale, key,
                                 duplicateCheck));
                     }
-                    duplicateCheck.reset();
                 }
             }
         }

--- a/org.eclipse.babel.tapiji.tools.target/org.eclipse.babel.tapiji.tools.target.target
+++ b/org.eclipse.babel.tapiji.tools.target/org.eclipse.babel.tapiji.tools.target.target
@@ -9,4 +9,5 @@
 <repository location="https://download.eclipse.org/releases/2023-09/202309131000/"/>
 </location>
 </locations>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Fixed the reporting of duplicate values + bonus fix: the Execution Environment is now set in the target platform file.